### PR TITLE
Redo Changes for /home

### DIFF
--- a/src/BPEssentials/Commands/Home/Home.cs
+++ b/src/BPEssentials/Commands/Home/Home.cs
@@ -24,7 +24,7 @@ namespace BPEssentials.Commands
             }
 
             ShApartment apartment = apartments[Math.Max(0, homeNumber - 1)];
-            player.GetExtendedPlayer().ResetAndSavePosition(apartment.GetPosition + offset, apartment.GetRotation, apartment.GetPlaceIndex);
+            player.GetExtendedPlayer().ResetAndSavePosition(apartment.spawnPoint.position, apartment.spawnPoint.rotation, apartment.GetPlaceIndex);
         }
     }
 }

--- a/src/BPEssentials/Commands/Home/Home.cs
+++ b/src/BPEssentials/Commands/Home/Home.cs
@@ -23,13 +23,7 @@ namespace BPEssentials.Commands
                 return;
             }
 
-            Vector3 offset = new Vector3(-1, 0, -1);
             ShApartment apartment = apartments[Math.Max(0, homeNumber - 1)];
-            if (apartment.GetRotation.y < 0.9)
-            {
-                offset = new Vector3(1, 0, 2);
-            }
-
             player.GetExtendedPlayer().ResetAndSavePosition(apartment.GetPosition + offset, apartment.GetRotation, apartment.GetPlaceIndex);
         }
     }


### PR DESCRIPTION
It seems that here:
https://github.com/BPEssentials/Core/commit/d1e1fe05e5fd5b8a30a53643f54e086d10015135#diff-50e67b2282d4039e9b9d4b88217c2d8e237016dda0bc0c5a13a635e7d40a001f The old offset system was used again, but this does not work for all cases. So instead the spawnPoint ( the green circle's postion ) will be used.