### PR TITLE
Packet flags

### DIFF
--- a/src/BPEssentials/BPEssentials.csproj
+++ b/src/BPEssentials/BPEssentials.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <!-- Only needed for windows as it is suggested to create a soft link/symlink on unix -->
-  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-    <PostBuildEvent>copy /Y "$(TargetFileName)" "$(BPDIR)\Plugins"</PostBuildEvent>
-  </PropertyGroup>
+    <Target  Condition="'$(OS)' == 'Windows_NT'" Name="PostBuild" AfterTargets="PostBuildEvent">
+      <Exec Command="copy /Y &quot;$(OutDir)\$(TargetFileName)&quot; &quot;$(BPDIR)\Plugins&quot;" />
+    </Target>
 
   <!-- <PropertyGroup Condition="'$(OS)' == 'UNIX'">
     <PostBuildEvent>cp "$(TargetFileName)" "$(BPDIR)/Plugins"</PostBuildEvent>

--- a/src/BPEssentials/ChatHandlers/LocalChat.cs
+++ b/src/BPEssentials/ChatHandlers/LocalChat.cs
@@ -61,7 +61,7 @@ namespace BPEssentials.ChatHandlers
             }
             if (Core.Instance.Settings.General.LocalChatInChat)
             {
-                player.svPlayer.Send(SvSendType.LocalOthers, Channel.Unsequenced, ClPacket.GameMessage, ChatUtils.FormatMessage(player, message, "format.local"));
+                player.svPlayer.Send(SvSendType.LocalOthers, Channel.Reliable, ClPacket.GameMessage, ChatUtils.FormatMessage(player, message, "format.local"));
             }
         }
     }

--- a/src/BPEssentials/ExtensionMethods/Player.cs
+++ b/src/BPEssentials/ExtensionMethods/Player.cs
@@ -48,7 +48,7 @@ namespace BPEssentials.ExtensionMethods
         public static void SendChatMessage(this ShPlayer player, string message, bool useColors = false)
         {
             message = useColors ? message.ParseColorCodes() : message;
-            player.svPlayer.Send(SvSendType.Self, Channel.Unsequenced, ClPacket.GameMessage, message);
+            player.svPlayer.Send(SvSendType.Self, Channel.Reliable, ClPacket.GameMessage, message);
         }
     }
 }


### PR DESCRIPTION
When Servers are Lagging Unsequenced Packets gets dropped, using Reliable for Messages will fix that. 
Vanilla also uses Reliable for GameMessages