### PR TITLE
Add Message for when no Kit/Warp exists

### DIFF
--- a/dist/localization.json
+++ b/dist/localization.json
@@ -115,7 +115,7 @@
     "user_not_ban": "{0} is not banned.",
     "pm>": "[PM] {0} > {1}",
     "pm<": "[PM] {0} < {1}",
-    "god_damage_blocked_minimal":  "Damage blocked: {0}HP.",
+    "god_damage_blocked_minimal": "Damage blocked: {0}HP.",
     "info_title": "User Info",
     "warn_list_title": "Warn List",
     "expFileHandler_deleted": "The {0} {1} has been deleted!",
@@ -126,7 +126,9 @@
     "player_giveammo_fail": "You do not have a weapon that needs ammo in your hands!",
     "player_tpahere_all": "Tpa here request sent to everyone!",
     "target_tpahere_sent": "{0} sent you a TPAHere request! Type /tpaccept to accept it.",
-    "player_tpahere_sent": "Sent a TPAHere request to {0}."
+    "player_tpahere_sent": "Sent a TPAHere request to {0}.",
+    "expFileHandler_error_none": "There is no {0} configured on this Server!"
+
   },
   "BR": {
     "arrested": "Preso {0}.",

--- a/dist/localization.json
+++ b/dist/localization.json
@@ -128,7 +128,6 @@
     "target_tpahere_sent": "{0} sent you a TPAHere request! Type /tpaccept to accept it.",
     "player_tpahere_sent": "Sent a TPAHere request to {0}.",
     "expFileHandler_error_none": "There is no {0} configured on this Server!"
-
   },
   "BR": {
     "arrested": "Preso {0}.",

--- a/src/BPEssentials.sln
+++ b/src/BPEssentials.sln
@@ -12,7 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\dist\localization.json = ..\dist\localization.json
 		..\dist\settings.json = ..\dist\settings.json
 		..\dist\CustomCommands.json = ..\dist\CustomCommands.json
-
 	EndProjectSection
 EndProject
 Global

--- a/src/BPEssentials.sln
+++ b/src/BPEssentials.sln
@@ -1,11 +1,19 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28917.182
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BPEssentials", "BPEssentials\BPEssentials.csproj", "{AFE6CE3D-2FE4-4C67-B71C-7DA67FA73766}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BP-CoreLib", "..\..\BP-CoreLib\src\BP-CoreLib\BP-CoreLib.csproj", "{573A3947-382A-409B-95E6-176E8D5BC686}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
+	ProjectSection(SolutionItems) = preProject
+		..\dist\localization.json = ..\dist\localization.json
+		..\dist\settings.json = ..\dist\settings.json
+		..\dist\CustomCommands.json = ..\dist\CustomCommands.json
+
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/BPEssentials/Commands/Kits/Kit.cs
+++ b/src/BPEssentials/Commands/Kits/Kit.cs
@@ -12,6 +12,12 @@ namespace BPEssentials.Commands
     {
         public void Invoke(ShPlayer player, string kit)
         {
+            if (Core.Instance.KitHandler.List.Count == 0)
+            {
+                player.TS("expFileHandler_error_none", player.T(Core.Instance.KitHandler.Name));
+                return;
+            }
+
             KitHandler.JsonModel obj = Core.Instance.KitHandler.List.FirstOrDefault(x => x.Name.Equals(kit, StringComparison.OrdinalIgnoreCase));
             if (obj == null)
             {

--- a/src/BPEssentials/Commands/Warps/Warp.cs
+++ b/src/BPEssentials/Commands/Warps/Warp.cs
@@ -12,6 +12,12 @@ namespace BPEssentials.Commands
     {
         public void Invoke(ShPlayer player, string warp)
         {
+            if(Core.Instance.WarpHandler.List.Count == 0)
+            {
+                player.TS("expFileHandler_error_none", player.T(Core.Instance.WarpHandler.Name));
+                return;
+            }
+
             WarpHandler.JsonModel obj = Core.Instance.WarpHandler.List.FirstOrDefault(x => x.Name.Equals(warp, StringComparison.OrdinalIgnoreCase));
             if (obj == null)
             {


### PR DESCRIPTION
```
========================== Advanced Event Error Tracker ==========================
Timestamp 04/22/2025 18:03:14
PluginName: BPEssentials
Methode Name: OnEvent
ExecutionMode: Override
EventID: 503
Event Name: PlayerChatGlobal
Full Signature: System.Void BPEssentials.ChatHandlers.GlobalChat::OnEvent(BrokeProtocol.Entities.ShPlayer player, System.String message)
Assembly FullName: BPEssentials, Version=3.2.3.0, Culture=neutral, PublicKeyToken=null
Assembly Location: /home/container/Plugins/BPEssentials(1).dll
InvocationList: 1
Methode Args: player, message
Type Methode: BrokeProtocol.Entities.ShPlayer, System.String
Type Event  : BrokeProtocol.Entities.ShPlayer, System.String
Advanced Argument Report:
Arg 0:  ShPlayer: ConstructionBrown (BrokeProtocol.Entities.ShPlayer): Player: PLASMA_chicken (822.71, 1.00, 788.55) 0
Arg 1:  String: /kit a: 
Event Exception:
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object
  at BPEssentials.Commands.Kit.Invoke (BrokeProtocol.Entities.ShPlayer player, System.String kit) [0x00149] in <bb222760e99d4539808831f06dfcf079>:0 
  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <069d7b80a3914a08b6825aa362b07f5e>:0 
   --- End of inner exception stack trace ---
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00083] in <069d7b80a3914a08b6825aa362b07f5e>:0 
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <069d7b80a3914a08b6825aa362b07f5e>:0 
  at BrokeProtocol.API.Command.Invoke (BrokeProtocol.Entities.ShPlayer player, System.String[] args, System.Int32 inputCount) [0x00043] in <ff3a0f80acdd495ab189773c1d008bec>:0 
  at BrokeProtocol.API.CommandHandler.OnEvent (BrokeProtocol.Entities.ShPlayer player, System.String message) [0x000b3] in <ff3a0f80acdd495ab189773c1d008bec>:0 
  at BPEssentials.ChatHandlers.GlobalChat.OnEvent (BrokeProtocol.Entities.ShPlayer player, System.String message) [0x0000f] in <bb222760e99d4539808831f06dfcf079>:0 
  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <069d7b80a3914a08b6825aa362b07f5e>:0 
   --- End of inner exception stack trace ---
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00083] in <069d7b80a3914a08b6825aa362b07f5e>:0 
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <069d7b80a3914a08b6825aa362b07f5e>:0 
  at BetterBPApiLoader.Core+SourceHandler_Exec_Patch.Prefix (System.Boolean& __result, BrokeProtocol.API.DelegateContainer __instance, System.Object[] args) [0x000b8] in <6481a5d37cf246d5994f7fa33e034165>:0 
Exception has been thrown by the target of an invocation.
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00083] in <069d7b80a3914a08b6825aa362b07f5e>:0 
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <069d7b80a3914a08b6825aa362b07f5e>:0 
  at BetterBPApiLoader.Core+SourceHandler_Exec_Patch.Prefix (System.Boolean& __result, BrokeProtocol.API.DelegateContainer __instance, System.Object[] args) [0x000b8] in <6481a5d37cf246d5994f7fa33e034165>:0 
```